### PR TITLE
Fix logout redirect

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -66,7 +66,7 @@ class Module extends \yii\base\Module {
     /**
      * @var array|string Url to redirect to after logging out
      */
-    public $logoutRedirect = ["@web"];
+    public $logoutRedirect = "@web";
 
     /**
      * @var bool If true, users will have to confirm their email address after registering (= email activation)


### PR DESCRIPTION
Updated property logoutRedirect to alias "@web" …

The use of the value "/" caused a 404 Error, under certain settings of the urlManager / pretty URLs.

``` php
...
        'urlManager' => [
            'enablePrettyUrl' => true,
            //'enableStrictParsing' => true,
            'showScriptName' => false,
            'suffix' => '/',
            'rules' => [
                //custom site controller rules
                '' => 'site/index',
                '<_a:(about|contact|error|captcha)>' => 'site/<_a>',
...
```
