### PR TITLE
Set username conditionally based on $useUsername module setting

### DIFF
--- a/controllers/DefaultController.php
+++ b/controllers/DefaultController.php
@@ -132,10 +132,13 @@ class DefaultController extends Controller
 
         // load post data
         $post = Yii::$app->request->post();
-        if ($userToken && $user->load($post)) {
+        if ($userToken) {
 
             // ensure that email is taken from the $userToken (and not from user input)
             $user->email = $userToken->data;
+
+			// set username if $useUsername is set to true
+			$user->username = $this->module->useUsername ? $post['User']['username'] : null;
 
             // validate and register
             $profile->load($post);


### PR DESCRIPTION
This commit intends to address a situation where the module config
settings are set to not use the Username field (i.e. ‘useUsername’ =>
false) and a user is trying to use the login/register via email feature.
- previously, trying to load the User from the post would fail when
useUsername is set to false because there are no User fields on the
form for Yii to load.
- This change should fix the issue by not trying to load the User from
the post, but rather only setting the $user->username if the module
settings call for using the username field.