### PR TITLE
Add Yii2 date conversion to admin panel

### DIFF
--- a/messages/fa/user.php
+++ b/messages/fa/user.php
@@ -1,0 +1,109 @@
+<?php
+
+return [
+
+    // models
+    'ID' => 'شناسه',
+    'User ID' => 'شناسه کاربری',
+    'Created At' => 'ایجادشده در',
+    'Updated At' => 'بروزشده در',
+    'Full Name' => 'نام کامل',
+
+    'Name' => 'نام',
+    'Can Admin' => 'مدیر باشد',
+
+    'Role' => 'نقش',
+    'Role ID' => 'شناسه نقش',
+    'Status' => 'وضعیت',
+    'Email' => 'پست الکترونیک',
+    'New Email' => 'پست الکترونیک جدید',
+    'Username' => 'نام کاربری',
+    'Password' => 'رمز عبور',
+    'Auth Key' => 'کلید اهراز هویت',
+    'Access Token' => 'توکن دسترسی',
+    'Logged In Ip' => 'IP ورود',
+    'Logged In At' => 'زمان ورود',
+    'Created Ip' => 'IP سازنده',
+    'Banned At' => 'مسدودشده در',
+    'Banned Reason' => 'دلیل انسداد',
+    'Current Password' => 'رمز عبور فعلی',
+    'New Password' => 'رمز عبور جدید',
+    'New Password Confirm' => 'تائید رمز عبور جدید',
+    'Email Confirmation' => 'پست الکترونیک تائید',
+
+    'Provider' => 'ارائه‌دهنده',
+    'Provider ID' => 'شناسه ارائه‌دهنده',
+    'Provider Attributes' => '',
+
+    'Type' => 'نوع',
+    'Token' => '',
+    'Expired At' => '',
+
+    'Time zone' => 'منطقه زمانی',
+
+    // models/forms
+    'Email not found' => 'پست الکترونیک یافت نشد',
+    'Email / Username' => 'پست الکترونیک / نام کاربری',
+    'Email / Username not found' => 'پست الکترونیک / نام کاربری یافت نشد',
+    'Username not found' => 'نام کاربری یافت نشد',
+    'User is banned - {banReason}' => 'کاربر مسدود شده است - {banReason}',
+    'Incorrect password' => 'رمزعبور نامعتبر',
+    'Remember Me' => 'مرا به یاد سپار',
+    'Email is already active' => 'پست الکترونیک از قبل فعال شده است',
+    'Passwords do not match' => 'رمز عبورها منطبق نیستند',
+    '{attribute} can contain only letters, numbers, and "_"' => '{attribute} تنها می‌تواند حروف الفبای انگلیسی، اعداد و "_" باشد',
+
+    'Data' => 'داده',
+
+    // controllers
+    'Successfully registered [ {displayName} ]' => '[ {displayName} ] با موفقیت ثبت شد',
+    ' - Please check your email to confirm your account' => ' - لطفا پست الکترونیک‌تان را برای فرآیند تائید حساب‌تان چک کنید',
+    'Account updated' => 'حساب بروز شد',
+    'Profile updated' => 'پروفایل بروز شد',
+    'Confirmation email resent' => 'پست الکترونیک تائید دوباره مجددا ارسال شد',
+    'Email change cancelled' => 'تغییر پست الکترونیک لغو شد',
+    'Instructions to reset your password have been sent' => 'شیوه‌ی بازنشانی رمز عبور برای شما ارسال شد',
+
+    // mail
+    'Please confirm your email address by clicking the link below:' => 'لطفا حساب خود را با کلیک بر روی پیوند زیر تائید کنید:',
+    'Please use this link to reset your password:' => 'لطفا از این پیوند برای بازنشانی رمز عبورتان استفاده کنید:',
+
+    // admin views
+    'Users' => 'کاربران',
+    'Banned' => 'مسدودشده',
+    'Create' => 'ساخت',
+    'Update' => 'بروزرسانی',
+    'Delete' => 'حذف',
+    'Search' => 'جستجو',
+    'Reset' => 'بازنشانی',
+    'Create {modelClass}' => 'ساخت {modelClass}',
+    'Update {modelClass}: ' => 'بروزرسانی {modelClass}',
+    'Are you sure you want to delete this item?' => 'آیا از حذف این مورد مطمئنید؟',
+    'User' => 'کاربر',
+    '{0, date, MMMM dd, YYYY HH:mm:ss}' => '{0, date, dd MMMM YYYY، HH:mm:ss}',
+
+    // default views
+    'Account' => 'حساب',
+    'Pending email confirmation: [ {newEmail} ]' => 'منتظر تائید پست الکترونیک: [ {newEmail} ]',
+    'Cancel' => 'لغو',
+    'Changing your email requires email confirmation' => 'تغییر پست الکترونیک شما نیاز به تائید مجدد پست الکترونیک دارد',
+    'Confirmed' => 'تائید‌شده',
+    'Error' => 'خطا',
+    'Your email [ {email} ] has been confirmed' => 'پست الکترونیک [ {email} ] متعلق به شما تائید شد',
+    'Go to my account' => 'رفتن به حساب کاربری من',
+    'Go home' => 'رفتن به خانه',
+    'Log in here' => 'ورود از اینجا',
+    'Invalid Token' => 'توکن نامعتبر',
+    'Forgot password' => 'فراموشی رمز عبور',
+    'Submit' => 'ارسال',
+    'Yii 2 User' => 'کاربر ئی ۲',
+    'Login' => 'ورود',
+    'Register' => 'ثبت‌نام',
+    'Logout' => 'خروج',
+    'Resend confirmation email' => 'بازارسال تائیدیه پست الکترونیک',
+    'Profile' => 'پروفایل',
+    'Resend' => 'بازارسال',
+    'Password has been reset' => 'رمزعبور بازنشانی شد',
+    'Login link sent - Please check your email' => 'پیوند ورود ارسال شد - لطفا پست الکترونیک خود را بررسی کنید',
+    'Registration link sent - Please check your email' => 'پیوند ثبت‌نام ارسال شد - لطفا پست الکترونیک خود را بررسی کنید',
+];

--- a/views/admin/create.php
+++ b/views/admin/create.php
@@ -9,7 +9,7 @@ use yii\helpers\Html;
  */
 
 $this->title = Yii::t('user', 'Create {modelClass}', [
-  'modelClass' => 'User',
+  'modelClass' => Yii::t('user', 'User'),
 ]);
 $this->params['breadcrumbs'][] = ['label' => Yii::t('user', 'Users'), 'url' => ['index']];
 $this->params['breadcrumbs'][] = $this->title;

--- a/views/admin/index.php
+++ b/views/admin/index.php
@@ -27,7 +27,7 @@ $this->params['breadcrumbs'][] = $this->title;
 
     <p>
         <?= Html::a(Yii::t('user', 'Create {modelClass}', [
-          'modelClass' => 'User',
+          'modelClass' => Yii::t('user', 'User'),
         ]), ['create'], ['class' => 'btn btn-success']) ?>
     </p>
 
@@ -60,7 +60,16 @@ $this->params['breadcrumbs'][] = $this->title;
             'email:email',
             'profile.full_name',
             'profile.timezone',
-            'created_at',
+            [
+                'attribute' => 'created_at',
+                'value' => function ($model) {
+                    if (extension_loaded('intl')) {
+                        return Yii::t('user', '{0, date, MMMM dd, YYYY HH:mm:ss}', [strtotime($model->created_at)]);
+                    }
+
+                    return $model->created_at;
+                }
+            ],
             // 'username',
             // 'password',
             // 'auth_key',

--- a/views/admin/update.php
+++ b/views/admin/update.php
@@ -9,7 +9,7 @@ use yii\helpers\Html;
  */
 
 $this->title = Yii::t('user', 'Update {modelClass}: ', [
-  'modelClass' => 'User',
+  'modelClass' => Yii::t('user', 'User'),
 ]) . ' ' . $user->id;
 $this->params['breadcrumbs'][] = ['label' => Yii::t('user', 'Users'), 'url' => ['index']];
 $this->params['breadcrumbs'][] = ['label' => $user->id, 'url' => ['view', 'id' => $user->id]];

--- a/views/admin/view.php
+++ b/views/admin/view.php
@@ -40,11 +40,59 @@ $this->params['breadcrumbs'][] = $this->title;
             'auth_key',
             'access_token',
             'logged_in_ip',
-            'logged_in_at',
+            [
+                'attribute' => 'logged_in_at',
+                'value' => call_user_func(function ($model) {
+                    if (!$model->logged_in_at) {
+                        return null;
+                    }
+
+                    if (extension_loaded('intl')) {
+                        return Yii::t('user', '{0, date, MMMM dd, YYYY HH:mm:ss}', [strtotime($model->logged_in_at)]);
+                    }
+
+                    return $model->logged_in_at;
+                }, $user)
+            ],
             'created_ip',
-            'created_at',
-            'updated_at',
-            'banned_at',
+            [
+                'attribute' => 'created_at',
+                'value' => call_user_func(function ($model) {
+                    if (extension_loaded('intl')) {
+                        return Yii::t('user', '{0, date, MMMM dd, YYYY HH:mm:ss}', [strtotime($model->created_at)]);
+                    }
+
+                    return $model->created_at;
+                }, $user)
+            ],
+            [
+                'attribute' => 'updated_at',
+                'value' => call_user_func(function ($model) {
+                    if (!$model->updated_at) {
+                        return null;
+                    }
+
+                    if (extension_loaded('intl')) {
+                        return Yii::t('user', '{0, date, MMMM dd, YYYY HH:mm:ss}', [strtotime($model->updated_at)]);
+                    }
+
+                    return $model->updated_at;
+                }, $user)
+            ],
+            [
+                'attribute' => 'banned_at',
+                'value' => call_user_func(function ($model) {
+                    if (!$model->banned_at) {
+                        return null;
+                    }
+
+                    if (extension_loaded('intl')) {
+                        return Yii::t('user', '{0, date, MMMM dd, YYYY HH:mm:ss}', [strtotime($model->banned_at)]);
+                    }
+
+                    return $model->banned_at;
+                }, $user)
+            ],
             'banned_reason',
         ],
     ]) ?>


### PR DESCRIPTION
### Description
This merge request add ability of automatic date converting, based on `Yii::t` function and `php-intl` extension to module. If this extension is installed in server and user had been selected a language expect `en` on `config.php` file, localized date will be shown. Also Farsi translation will add to project with this merge request.

PS. I think `'{0, date, MMMM dd, YYYY HH:mm:ss}' => '{0, date, dd MMMM YYYY، HH:mm:ss}',` (Based on correct regional format) must be added to all translation files for correct showing of date.

### Example
Without this lines 
```php
$config = [
    'id' => 'basic',
    // Some code go here
    'sourceLanguage' => 'en-US',
    'language' => 'fa-IR',
    // Some code go here
```
on `web/config.php` date is like this:
![screen shot 2016-10-20 at 15 15 51](https://cloud.githubusercontent.com/assets/1416085/19558652/822b7e72-96d8-11e6-8d03-9860e017ac6e.png)
and with them is like this:
![screen shot 2016-10-20 at 15 15 24](https://cloud.githubusercontent.com/assets/1416085/19558662/92c618e6-96d8-11e6-8f9d-632e57ccf0c2.png)
which is a correct Jalali date.