### PR TITLE
Fixed Issue: Undefined index: emails

### DIFF
--- a/controllers/AuthController.php
+++ b/controllers/AuthController.php
@@ -284,8 +284,8 @@ class AuthController extends Controller
         $user = $this->module->model("User");
         $profile = $this->module->model("Profile");
 
-        $user->email = $attributes["emails"][0]["value"];
-        $profile->full_name = "{$attributes["name"]["givenName"]} {$attributes["name"]["familyName"]}";
+        $user->email = isset($attributes["email"]) ? $attributes["email"] : $attributes["emails"][0]["value"];
+        $profile->full_name = isset($attributes["name"]["givenName"]) ? "{$attributes["name"]["givenName"]} {$attributes["name"]["familyName"]}" : $attributes["name"];
 
         return [$user, $profile];
     }


### PR DESCRIPTION
Problem:

    PHP Notice – yii\base\ErrorException
    Undefined index: emails

Since Google + Api is deprecated and isn't accepting new domains; this plugin still works for old websites that implements this plugin, but isn't working for new domains. It returns `email` instead of `emails` from the people API

reference: [Google+ API Shutdown](https://developers.google.com/+/api-shutdown)